### PR TITLE
Use 101 uid (systemd-network) user for nginx web service

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,4 +6,5 @@ RUN chmod 777 /var/cache/nginx
 RUN rm -rf /etc/nginx/conf.d/*
 COPY proxy_params nginx.conf /etc/nginx/
 
-USER nginx
+# Drop root privileges, maps to `systemd-network` user on local dev & prod system
+USER 101:101


### PR DESCRIPTION
Ensures that the `web` service runs with `uid` and `gid` 101 (maps to `systemd-network` on local machine) and has ownership to local tiles cache (at `/tmp/tiles`).