### PR TITLE
Add support to show marked tracks on maps

### DIFF
--- a/tiles/server.js
+++ b/tiles/server.js
@@ -41,8 +41,10 @@ if (cluster.isMaster) {
   const TILE_LENGTH = 256;
   const CIRCLE_RADIUS = 4;
 
-  app.get('/api/v1/tiles/:zoom/:x/:y', function(req, res) {
+  app.get('/api/v1/tiles/:zoom/:x/:y/:mark?/:all?', function(req, res) {
 
+    let mark = req.params.mark
+	let include_old_data = req.params.all
     let coords = {x: req.params.x, y: req.params.y};
     let zoom = req.params.zoom;
 
@@ -63,10 +65,20 @@ if (cluster.isMaster) {
       bbox[3] + bboxOffset
     ];
 
+	var path_str = `/ws/?bbox=${bboxExt}&zoom_level=${zoom}`
+	
+	if (mark) {
+        path_str += `&mark=${mark}` 
+    }
+	
+	if (include_old_data) {
+        path_str += `&all=1` 
+    }
+	
     let params = {
       host: SRS_HOST,
       port: SRS_PORT,
-      path: `/ws/?bbox=${bboxExt}&zoom_level=${zoom}`
+      path: path_str
     };
 
     console.log(params);
@@ -80,7 +92,6 @@ if (cluster.isMaster) {
       });
 
       resp.on('end', function() {
-
         console.log('End GET');
         let values = JSON.parse(data);
         console.log(`elements: ${values.features.length}`);

--- a/ws/config.php
+++ b/ws/config.php
@@ -9,7 +9,8 @@ function _getenv($env, $default) {
 // aggregate database
 DEFINE("DB_HOST", _getenv("AGG_DB_HOST", "agg-db"));
 DEFINE("DB_PORT", _getenv("AGG_DB_PORT", "5432"));
-DEFINE("DB_NAME", _getenv("AGG_DB_NAME", "srs_agg_db"));
+DEFINE("DB_RAW_NAME", _getenv("RAW_DB_NAME", "srs_raw_db"));
+DEFINE("DB_AGG_NAME", _getenv("AGG_DB_NAME", "srs_agg_db"));
 DEFINE("DB_USER", _getenv("AGG_DB_USER", "crowd4roads_sw"));
 DEFINE("DB_PASS", _getenv("AGG_DB_PASS", "password"));
 

--- a/ws/index.php
+++ b/ws/index.php
@@ -2,7 +2,11 @@
 
 require_once 'config.php';
 
-$srsDB = new SrsDB(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS);
+$clientMark = $_GET['mark'];
+$include_old_data = (isset($_GET['all']) && !empty($_GET['all']));
+
+$srsDB = new SrsDB(DB_HOST, DB_PORT, $clientMark == "" ? DB_AGG_NAME : DB_RAW_NAME, DB_USER, DB_PASS);
+
 
 // Handle request parameters
 $moduleFilter = 1;
@@ -29,12 +33,18 @@ else {
     // split the bbox into it's parts
     list($left, $bottom, $right, $top) = explode(",", $_GET['bbox']);
 
-
+	
+	
     $srsDB->open();
-    $data = $srsDB->SRS_Get_All_Current_Data($left, $bottom, $right, $top, $moduleFilter);
+	if ($clientMark == ""){
+		$data = $srsDB->SRS_Get_All_Current_Data($left, $bottom, $right, $top, $moduleFilter, $clientMark);
+		//LogUtil::get()->info("Points retrieved: " . print_r($data, true));
+	}else {
+		$data = $srsDB->SRS_Marked_Raw_Data($left, $bottom, $right, $top, $clientMark, $include_old_data);
+	}
     $srsDB->close();
 
-    LogUtil::get()->info("Points retrieved: " . print_r($data, true));
+    
 
     // Enclose data in GeoJson like structure.
     $ajxres = array();

--- a/ws/lib/SrsDB.php
+++ b/ws/lib/SrsDB.php
@@ -47,11 +47,42 @@ class SrsDB {
 
         //echo $result;
         if (!$result)
-            throw new Exception("Error Updating SRS Data Projections: " . pg_last_error($this->conn));
+            throw new Exception("Error Getting SRS Data: " . pg_last_error($this->conn));
 
         $data = pg_fetch_all($result);
 
         return ($data);
     }
 
+	public function SRS_Marked_Raw_Data($left, $bottom, $right, $top, $mark, $all_data) {
+        $updatedIndexes = array();
+		
+		$mark = mb_strtolower($mark);
+		
+		$query = "SELECT ppe, st_asgeoJson(position)
+            FROM single_data LEFT JOIN track ON track.track_id = single_data.track_id 
+			  WHERE
+			  LOWER(track.metadata::json->>'clientMark') = '$mark' AND 
+			  single_data.position && ST_MakeEnvelope( $left, $bottom, $right, $top , 4326) ";
+		
+		if($all_data) {
+			$query .= " UNION SELECT ppe, st_asgeoJson(position)
+            FROM single_data_old LEFT JOIN track ON track.track_id = single_data_old.track_id 
+			  WHERE
+			  LOWER(track.metadata::json->>'clientMark') = '$mark' AND 
+			  single_data_old.position && ST_MakeEnvelope( $left, $bottom, $right, $top , 4326) ";
+		}
+		
+		
+        $result = pg_query($this->conn, "$query ;");
+
+        //echo $result;
+        if (!$result)
+            throw new Exception("Error Updating SRS Data: " . pg_last_error($this->conn));
+
+        $data = pg_fetch_all($result);
+
+        return ($data);
+    }
+	
 }


### PR DESCRIPTION
Add backend functionalities to support the showing of raw marked data tracks on the SRS map.

_(from PR in the linked external repo: https://github.com/SmartRoadSense/website/pull/6)_
It makes possible to append _mark_ and _all_ get parameters to the http://smartroadsense.uniurb.it/data/map/ URL and to pass them through to backend services.

- _mark_ (e.g., http://smartroadsense.uniurb.it/it/data/map/?mark=test-1) to show only those raw data points collected in the last 7 days and associated with tracks marked with` "clientMark":"Test-1"` (it's case insensitive)
- _all_ (e.g.,  http://smartroadsense.uniurb.it/it/data/map/?mark=test-1&all=True) to also show data points older than 7 days (only work in conjunction with the _mark_ parameter)
