### PR TITLE
Update to Hugo 0.49 and add Git LFS support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     container_name: ui
     build: ./ui
     volumes:
-    - web_data:/output:rw
+    - web_data:/target:rw
 
   tiles:
     container_name: tiles
@@ -55,13 +55,13 @@ services:
     build: ./raw/web
     env_file: config.env
     restart: always
-    
+
   export:
     container_name: export
     build: ./export
     env_file: config.env
     volumes: ['./data:/data:rw']
-  
+
   bb:
     container_name: bb
     build: ./bb

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,30 +1,13 @@
-# ---
-# First stage (build)
-FROM debian:stretch-slim AS build
-WORKDIR /tmp
+FROM klakegg/hugo:0.49-ext-alpine
 
-# Configuration
-ENV HUGO_VERSION=0.43
-ENV HUGO_TYPE=_extended
-ENV HUGO_ID=hugo${HUGO_TYPE}_${HUGO_VERSION}
-
-# Get Hugo
-ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_ID}_Linux-64bit.tar.gz /tmp
-RUN tar -xf /tmp/${HUGO_ID}_Linux-64bit.tar.gz --directory=/tmp
-
-# ---
-# Second stage (build website)
-FROM debian:stretch-slim AS runtime
-WORKDIR /
-COPY --from=build /tmp/hugo /usr/local/sbin/hugo
-RUN apt update && apt install -y \
-    git
+RUN apk update \
+    && apk --no-cache add openssl git git-lfs
 
 # Copy script and allow execution
 COPY ./build-static-site.sh /build-static-site.sh
 RUN chmod 0777 /build-static-site.sh
 
 VOLUME /src
-VOLUME /output
+VOLUME /target
 
-CMD ["/build-static-site.sh"]
+ENTRYPOINT [ "/bin/sh", "-c", "/build-static-site.sh"]

--- a/ui/build-static-site.sh
+++ b/ui/build-static-site.sh
@@ -6,4 +6,4 @@ git clone https://github.com/SmartRoadSense/website.git /tmp/repository
 mv /tmp/repository/hugo/* /src
 
 echo "Building website…"
-hugo --source="/src" --destination="/output" --baseURL="$HUGO_BASEURL" "$@" || exit 1
+hugo --source="/src" --destination="/target" --baseURL="$HUGO_BASEURL" "$@" || exit 1


### PR DESCRIPTION
Reverts Hugo Docker image to `klakegg/hugo` v0.49 and adds Git LFS support for new website repository.