### PR TITLE
Revamp docker compose specifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+SHELL := /bin/bash
+
 ENV ?= prod
 DC := docker-compose -f docker-compose.yml -f docker-compose.${ENV}.yml
 DC_RUN := ${DC} run --rm
 
+.PHONY: confirmation
+confirmation:
+	@echo -n 'Are you sure? [y|N] ' && read ans && [ $$ans == y ]
 
 .PHONY: test
 test:
@@ -17,6 +22,17 @@ data:
 
 test/payload.json:
 	gzip -kd test/payload.json.gz
+
+.PHONY: create_volumes drop_volumes
+create_volumes:
+	docker volume create srs_web_data
+	docker volume create srs_open_data
+	@echo 'SmartRoadSense external volumes created'
+
+drop_volumes: confirmation
+	docker volume rm srs_web_data
+	docker volume rm srs_open_data
+	@echo 'SmartRoadSense external volumes dropped'
 
 .PHONY: up
 up: data build

--- a/agg/cli/Dockerfile
+++ b/agg/cli/Dockerfile
@@ -6,5 +6,17 @@ ENV PGHOST=agg-db \
     PGPASSWORD=password \
     PGPASS=password
 
+USER root
+
+# Prepare volume with correct permissions
+RUN mkdir /opendata
+RUN chown -R 1000:1000 /opendata
+VOLUME /opendata
+
+# Prepare home dir with correct permissions
 COPY ./ /code
+RUN chown -R 1000:1000 /code
+
+USER 1000
+
 WORKDIR /code

--- a/agg/cli/update_open_data.sh
+++ b/agg/cli/update_open_data.sh
@@ -6,7 +6,7 @@ DBCOLUMNS='"latitude","longitude","ppe","osm_id","highway","updated_at"'
 QUERY_DBCOLUMNS="st_Y(the_geom) as latitude, st_x(the_geom) as longitude, ppe, osm_id, highway, updated_at"
 
 FILENAME=open_data.csv
-FILENAMEZIP=/data/open_data.zip
+FILENAMEZIP=/opendata/open_data.zip
 TMP_FILENAME="tmp_$FILENAME"
 
 echo "Starting new db dump..."

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,7 +20,6 @@ services:
   #  build: ./agg/db
   #  volumes: ['agg_data:/var/lib/postgresql/data/srs:rw']
   #  ports: ['127.0.0.1:5433:5432']
-  #  restart: always
 
   raw-cli:
   #  depends_on: [raw-db]
@@ -32,7 +31,6 @@ services:
   #  build: ./raw/db
   #  volumes: ['raw_data:/var/lib/postgresql/data/srs:rw']
   #  ports: ['127.0.0.1:5431:5432']
-  #  restart: always
 
   export:
   #  depends_on: [raw-db, agg-db]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # Development-specific config
-version: '2'
+version: '3'
 services:
   web:
     ports: ['0.0.0.0:80:8080']

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,8 @@
 version: '3'
 services:
   web:
-    ports: ['0.0.0.0:80:8080']
+    ports:
+    - "0.0.0.0:80:8080"
     volumes:
     - ./web/prod.conf:/etc/nginx/conf.d/smartroadsense.conf:ro
 
@@ -13,7 +14,8 @@ services:
   agg-cli:
   #  depends_on: [agg-db]
   agg-web:
-    ports: ['0.0.0.0:9001:80']
+    ports:
+    - "0.0.0.0:9001:80"
   #  depends_on: [agg-db]
   #agg-db:
   #  container_name: agg-db
@@ -24,7 +26,8 @@ services:
   raw-cli:
   #  depends_on: [raw-db]
   raw-web:
-    ports: ['0.0.0.0:9002:80']
+    ports:
+    - "0.0.0.0:9002:80"
   #  depends_on: [raw-db]
   #raw-db:
   #  container_name: raw-db

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,8 @@
 version: '3'
 services:
   web:
-    ports: ['0.0.0.0:80:8080']
+    ports:
+    - "0.0.0.0:80:8080"
     volumes:
     - ./web/prod.conf:/etc/nginx/conf.d/smartroadsense.conf:ro
     - /tmp/tiles:/tmp/tiles:rw
@@ -18,7 +19,8 @@ services:
     restart: always
 
   agg-web:
-    ports: ['127.0.0.1:9001:80']
+    ports:
+    - "127.0.0.1:9001:80"
     restart: always
 
   bb:
@@ -31,5 +33,6 @@ services:
     restart: always
 
   raw-web:
-    ports: ['127.0.0.1:9002:80']
+    ports:
+    - "127.0.0.1:9002:80"
     restart: always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 # Production-specific config
-version: '2'
+version: '3'
 services:
   web:
     ports: ['0.0.0.0:80:8080']

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,13 +7,29 @@ services:
     - ./web/prod.conf:/etc/nginx/conf.d/smartroadsense.conf:ro
     - /tmp/tiles:/tmp/tiles:rw
     - /tmp/osm_tiles:/tmp/osm_tiles:rw
+    restart: always
 
   ui:
     environment:
     - HUGO_BASEURL=http://www.smartroadsense.it/
+    restart: always
+
+  tiles:
+    restart: always
 
   agg-web:
     ports: ['127.0.0.1:9001:80']
+    restart: always
+
+  bb:
+    restart: always
+
+  ws:
+    restart: always
+
+  api:
+    restart: always
 
   raw-web:
     ports: ['127.0.0.1:9002:80']
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     - ui
     - ws
     - api
-    restart: always
 
   ui:
     container_name: ui
@@ -34,7 +33,6 @@ services:
     volumes: ['./tiles:/code:ro']
     ports: ['127.0.0.1:8000:8000']
     depends_on: [ws]
-    restart: always
 
   agg-cli:
     container_name: agg-cli
@@ -46,7 +44,6 @@ services:
     container_name: agg-web
     build: ./agg/web
     env_file: config.env
-    restart: always
 
   raw-cli:
     container_name: raw-cli
@@ -58,7 +55,6 @@ services:
     container_name: raw-web
     build: ./raw/web
     env_file: config.env
-    restart: always
 
   export:
     container_name: export
@@ -71,21 +67,18 @@ services:
     build: ./bb
     env_file: config.env
     ports: ['127.0.0.1:8080:8080']
-    restart: always
 
   ws:
     container_name: ws
     build: ./ws
     env_file: config.env
     volumes: ['./ws:/code/ws:rw']
-    restart: always
 
   api:
     container_name: api
     build: ./api
     env_file: config.env
     volumes: ['./api:/code/api:rw']
-    restart: always
 
   map-reduce:
     container_name: map-reduce

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,18 @@
 # Common config
-version: '2'
+version: '3'
 volumes:
-  web_data: {}
+  srs_web_data:
+    external: true
+  srs_open_data:
+    external: true
+
 services:
   web:
     container_name: web
     build: ./web
     volumes:
-    - web_data:/www:ro
-    - ./data:/data:ro
+    - srs_web_data:/www:ro
+    - srs_open_data:/opendata:ro
     depends_on:
     - tiles
     - ui
@@ -20,7 +24,7 @@ services:
     container_name: ui
     build: ./ui
     volumes:
-    - web_data:/target:rw
+    - srs_web_data:/target:rw
 
   tiles:
     container_name: tiles
@@ -37,8 +41,7 @@ services:
     build: ./agg/cli
     env_file: config.env
     volumes:
-    - ./agg/cli:/code:rw
-    - ./data:/data:rw
+    - srs_open_data:/opendata:rw
   agg-web:
     container_name: agg-web
     build: ./agg/web
@@ -49,7 +52,8 @@ services:
     container_name: raw-cli
     build: ./raw/cli
     env_file: config.env
-    volumes: ['./raw/cli:/code:rw', './data:/data:rw']
+    volumes:
+    - ./raw/cli:/code:rw
   raw-web:
     container_name: raw-web
     build: ./raw/web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,12 @@ services:
     build: ./tiles
     env_file: config.env
     command: nodemon server.js
-    volumes: ['./tiles:/code:ro']
-    ports: ['127.0.0.1:8000:8000']
-    depends_on: [ws]
+    volumes:
+    - ./tiles:/code:ro
+    ports:
+    - "127.0.0.1:8000:8000"
+    depends_on:
+    - ws
 
   agg-cli:
     container_name: agg-cli
@@ -66,28 +69,33 @@ services:
     container_name: bb
     build: ./bb
     env_file: config.env
-    ports: ['127.0.0.1:8080:8080']
+    ports:
+    - "127.0.0.1:8080:8080"
 
   ws:
     container_name: ws
     build: ./ws
     env_file: config.env
-    volumes: ['./ws:/code/ws:rw']
+    volumes:
+    - ./ws:/code/ws:rw
 
   api:
     container_name: api
     build: ./api
     env_file: config.env
-    volumes: ['./api:/code/api:rw']
+    volumes:
+    - ./api:/code/api:rw
 
   map-reduce:
     container_name: map-reduce
     build: ./jobs/map-reduce
     env_file: config.env
-    volumes: ['./jobs/map-reduce:/code:ro']
+    volumes:
+    - ./jobs/map-reduce:/code:ro
 
   meta-updater:
     container_name: meta-updater
     build: ./jobs/meta-updater/
     env_file: config.env
-    volumes: ['./jobs/meta-updater:/code:ro']
+    volumes:
+    - ./jobs/meta-updater:/code:ro

--- a/web/prod.conf
+++ b/web/prod.conf
@@ -17,8 +17,8 @@ server {
   }
 
   location = /open_data.zip {
-    root /data;
     expires modified +6h;
+    root /opendata;
   }
 
   location ^~ /api/v1/tiles/ {


### PR DESCRIPTION
Switches to the Docker Compose **v3** specification (requires newer Docker and Docker Compose versions, which are already available in production).

*External volumes* are used to safely persist data when stopping/starting the service. This prevents `make down` from deleting data when removing images and anonymous volumes.
The external volumes (`srs_web_data` and `srs_open_data`, currently) are created via Makefile (commands `make create_volumes` and `make drop_volumes`).

The `restart: always` directive is removed in development (this fixes issue #22).