### PR TITLE
Speed up website generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,13 @@ test/payload.json:
 create_volumes:
 	docker volume create srs_web_data
 	docker volume create srs_open_data
+	docker volume create srs_ui_repo_data
 	@echo 'SmartRoadSense external volumes created'
 
 drop_volumes: confirmation
 	docker volume rm srs_web_data
 	docker volume rm srs_open_data
+	docker volume rm srs_ui_repo_data
 	@echo 'SmartRoadSense external volumes dropped'
 
 .PHONY: up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ volumes:
     external: true
   srs_open_data:
     external: true
+  srs_ui_repo_data:
+    external: true
 
 services:
   web:
@@ -24,6 +26,7 @@ services:
     build: ./ui
     volumes:
     - srs_web_data:/target:rw
+    - srs_ui_repo_data:/repo:rw
 
   tiles:
     container_name: tiles

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,5 +9,6 @@ RUN chmod 0777 /build-static-site.sh
 
 VOLUME /src
 VOLUME /target
+VOLUME /repo
 
 ENTRYPOINT [ "/bin/sh", "-c", "/build-static-site.sh"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:0.49-ext-alpine
+FROM klakegg/hugo:0.52-ext-alpine
 
 RUN apk update \
     && apk --no-cache add openssl git git-lfs

--- a/ui/build-static-site.sh
+++ b/ui/build-static-site.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 
-# Get website source
-echo "Retrieving website source…"
-git clone https://github.com/SmartRoadSense/website.git /tmp/repository
-mv /tmp/repository/hugo/* /src
+if [ -d "/repo/website" ]; then
+    echo "Pulling website updates…"
+    cd /repo/website
+    git pull --ff-only
+else
+    echo "Retrieving website source…"
+    git clone -b master --single-branch --no-tags https://github.com/SmartRoadSense/website.git /repo/website
+fi
+
+# Update source directory
+cp -r /repo/website/hugo/* /src
 
 echo "Building website…"
 hugo --source="/src" --destination="/target" --baseURL="$HUGO_BASEURL" "$@" || exit 1
+
+echo "Cleaning up…"
+rm -r /src/*


### PR DESCRIPTION
Upgrade to Hugo v0.52 and use an external Docker volume to store the website repository (prevents re-downloading the repo at each rebuild).