### PR TITLE
Fix newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Disable EOL processing
+* -text
+
+*.jpg -diff
+*.psd -diff
+*.png -diff


### PR DESCRIPTION
Disable the default newline processing by Git for Windows on all checked-in files.