### PR TITLE
Match new project name in Makefile removal directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,12 @@ rm rmc: stop
 
 .PHONY: rmi
 rmi: rmc
-	docker rmi $$(docker images | grep 'srs' | awk '{print $$1}')
+	docker rmi $$(docker images | grep 'smartroadsense_' | awk '{print $$1}')
 
 .PHONY: rmv
 rmv: stop
 	${DC} rm -fv
-	docker volume rm $$(docker volume ls | grep srs | awk '{print $$2}')
+	docker volume rm $$(docker volume ls | grep 'smartroadsense_' | awk '{print $$2}')
 
 sh_%:
 	${DC_RUN} $* /bin/bash


### PR DESCRIPTION
Since `Makefile` now uses “smartroadsense” as the fixed project name, `rmi` and `rmv` directives must be updated to correctly match image and volume names.