### PR TITLE
Update PostgreSQL client images, fixes #32

### DIFF
--- a/agg/cli/Dockerfile
+++ b/agg/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM smartroadsense/postgres-cli
+FROM smartroadsense/postgres-cli:2.0
 
 ENV PGHOST=agg-db \
     PGUSER=crowd4roads_sw \

--- a/raw/cli/Dockerfile
+++ b/raw/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM smartroadsense/postgres-cli
+FROM smartroadsense/postgres-cli:2.0
 
 ENV PGHOST=raw-db \
     PGUSER=crowd4roads_sw \


### PR DESCRIPTION
Updated image [smartroadsense/postgres-cli:2.0](https://hub.docker.com/r/smartroadsense/postgres-cli) is now based on Alpine and contains **psql** `v11.1` and **pgcli** `v2.0.2`.